### PR TITLE
feat: 新增前端 AI 开发规范与 skills 体系

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 **/.turbo
 **/.vite
 .vscode
-AGENTS.md
+# AGENTS.md
 backend/.env
 **/*.local
 **/.__mf__temp

--- a/frontend/.claude/skills/capabilities/i18n-setup.md
+++ b/frontend/.claude/skills/capabilities/i18n-setup.md
@@ -1,0 +1,154 @@
+---
+name: i18n-setup
+description: 设置并验证 Tier0 Edge/Enterprise 前端的 i18n 国际化能力，包含新页面接入、词条维护，以及 react-intl + useTranslate 的正确使用方式。
+---
+
+# i18n-setup（Edge/Enterprise）
+
+用于在本仓库中新增、改造、校验国际化能力，确保文案可维护、可协作、可回归。
+
+## 适用场景
+
+- 新页面接入 i18n
+- 现有页面补齐 i18n 文案
+- 插件暴露语言包
+- 确认语言切换行为正确
+
+## 技术栈说明
+
+本仓库使用 **react-intl + Zustand + Ant Design ConfigProvider** 组合：
+
+- 核心状态：`apps/web/src/stores/i18n-store.ts`
+- Provider：`apps/web/src/LanguageProvider.tsx`
+- 初始化函数：`initI18n`（先加载本地 JSON，再合并后端词条）
+- 词条源文件：`apps/web/src/locale/index.js`（中文源）
+- 词条生成文件：`apps/web/src/locale/zh-CN.json`、`apps/web/src/locale/en-US.json`
+
+## 必守约束
+
+- React 组件内使用 `useTranslate()` 或 `useTranslate('ComponentName')` 获取格式化函数。
+- 非 React 场景使用 `getIntl`，避免在组件里绕过响应式更新。
+- 用户可见文案必须国际化，禁止在组件内硬编码中英文字符串。
+- `src/locale/index.js` 是源文件，必须先在这里维护词条，再生成 JSON。
+- 不要只改 `zh-CN.json` 或 `en-US.json` 而漏掉 `index.js`。
+- AI 提取或新增 i18n key 时，末级 key 名尽量控制在 25 个字符以内，优先短语义命名，避免整句式 key。
+
+## 本仓库 i18n 调用约定
+
+### React 组件内
+
+```tsx
+import { useTranslate } from '@/hooks';
+
+// 无前缀：直接使用完整 key
+const formatMessage = useTranslate();
+<h1>{formatMessage({ id: 'feature.pageTitle' })}</h1>;
+
+// 有前缀：ComponentName 作为前缀
+const formatMessage = useTranslate('MyComponent');
+<button>{formatMessage({ id: 'save' })}</button>;
+// 实际查找 key：MyComponent.save
+```
+
+### 非 React 场景
+
+```ts
+import { getIntl } from '@/stores/i18n-store';
+
+const intl = getIntl();
+const text = intl.formatMessage({ id: 'feature.pageTitle' });
+```
+
+## 词条维护流程
+
+### 1) 在源文件中新增词条
+
+编辑 `apps/web/src/locale/index.js`，添加中文源词条：
+
+```js
+// src/locale/index.js
+export default {
+  // ... 现有词条
+  'feature.pageTitle': '功能页面',
+  'feature.save': '保存',
+  'feature.cancel': '取消',
+  'feature.deleteConfirm': '确定要删除吗？',
+};
+```
+
+### 2) 生成 JSON 文件
+
+```bash
+pnpm intl:once
+# 或监听模式（开发期间）
+pnpm intl:watch
+```
+
+生成结果：
+
+- `apps/web/src/locale/zh-CN.json`（中文）
+- `apps/web/src/locale/en-US.json`（英文，需要翻译的留空或填英文）
+
+### 3) 补充英文词条
+
+在 `en-US.json` 中补充英文翻译：
+
+```json
+{
+  "feature.pageTitle": "Feature Page",
+  "feature.save": "Save",
+  "feature.cancel": "Cancel",
+  "feature.deleteConfirm": "Are you sure you want to delete?"
+}
+```
+
+### 4) 验证
+
+- 切换语言后确认 UI 文案正确
+- 确认无 missing key 警告（浏览器 Console）
+- 运行 lint：`pnpm lint`
+
+## 新页面接入 i18n 完整示例
+
+```tsx
+import { type FC } from 'react';
+import { Button } from 'antd';
+import { useTranslate } from '@/hooks';
+
+const FeaturePage: FC = () => {
+  const formatMessage = useTranslate('FeaturePage');
+
+  return (
+    <div>
+      <h1>{formatMessage({ id: 'title' })}</h1>
+      <Button onClick={handleSave}>{formatMessage({ id: 'save' })}</Button>
+    </div>
+  );
+};
+```
+
+对应 `src/locale/index.js` 词条：
+
+```js
+'FeaturePage.title': '功能页面',
+'FeaturePage.save': '保存',
+```
+
+## 插件语言包
+
+模块联邦插件必须暴露 `./zhCN` 与 `./enUS` 语言包，参考 `plugins/vite.base.ts`。插件内部调用 `useTranslate(REMOTE_NAME)` 确保 key 自动带插件前缀，避免与主应用 key 冲突。
+
+## 注意事项
+
+- `dayjs` 语言在 `initI18n` 中同步切换；新增日期/时间格式化能力时确认是否跟随当前语言。
+- Ant Design 组件语言由 `loadAntdLocale` 动态加载，分页、弹窗、空态等默认文案复用已有 key。
+- 若扩展新语言（除 `zh-CN`/`en-US` 外），需同时检查：前端本地语言文件、后端语言列表接口、Ant Design locale 映射、插件语言包。
+
+## 验收清单
+
+- `src/locale/index.js` 已定义所有新增词条
+- 运行 `pnpm intl:once` 后 `zh-CN.json` 与 `en-US.json` 已同步
+- `en-US.json` 已补充英文翻译
+- 切换语言可见文案完整正确
+- 无 missing key 报错
+- 无临时调试代码（如 `console.log`）遗留

--- a/frontend/.claude/skills/capabilities/tier0-page-api-integration.md
+++ b/frontend/.claude/skills/capabilities/tier0-page-api-integration.md
@@ -1,0 +1,91 @@
+---
+name: tier0-page-api-integration
+description: 在 Tier0 Edge/Enterprise 前端中完成页面与后端 API 的稳定对接。用于将页面动作接入 src/apis/inter-api/、处理请求状态与错误反馈，并完成端到端页面联调。
+---
+
+# Tier0 页面 API 对接（Edge/Enterprise）
+
+## 概览
+
+将页面交互可靠接入后端 API 服务层，保证请求行为可预测、可维护。
+
+## 工作流
+
+1. 明确 API 合同与 endpoint（路径、方法、请求/响应字段）。
+2. 先确认 `src/apis/inter-api/<module>.ts` 是否已有对应方法；没有则先补。
+3. 在页面中接入 service，显式处理：
+   - `loading`（加载中状态）
+   - `success`（成功反馈）
+   - `error`（失败提示）
+4. 请求参数映射集中放在提交逻辑附近，不分散在展示组件里。
+5. 若页面已使用 Zustand store，沿用该层承载数据获取与变更。
+6. 错误提示复用现有模式（`message.error`、`notification`、行内错误等）。
+7. 页面对接产生的用户可见文案（成功/失败提示、空态文案、按钮文案）统一走 i18n key，不直接硬编码字符串。
+
+## 对接规则
+
+### API Service 层约束
+
+- **统一使用 `ApiWrapper`** 封装请求，禁止在页面组件内直接使用 `axios` 或 `fetch`。
+- Service 函数放在 `src/apis/inter-api/<module>.ts`，所有 API 从 `src/apis/inter-api/index.ts` 统一导出。
+- Service 函数保持薄且确定：只做参数整形 + 请求发送 + 响应映射，不含业务逻辑。
+- 方法命名与同文件风格一致（如 `getXxxApi`、`createXxxApi`、`updateXxxApi`、`deleteXxxApi`）。
+
+```typescript
+// 示例：src/apis/inter-api/feature.ts
+import { ApiWrapper } from '@/utils/request';
+
+const api = new ApiWrapper('/inter-api/supos/feature');
+
+export const getFeatureListApi = async (params: GetFeatureListParams) => {
+  return api.get('', { params });
+};
+
+export const createFeatureApi = async (data: CreateFeatureRequest) => {
+  return api.post('', data);
+};
+```
+
+### 页面层约束
+
+- 展示型深层组件中不直接发请求。
+- 禁止在页面/组件内拼接后端 URL，必须通过 `src/apis/inter-api/` 调用。
+- 使用 Zustand store 承载列表数据、分页状态、加载状态时，store action 内直接调用 service。
+- 使用 `usePagination` hook 统一管理分页逻辑。
+
+### 状态处理规范
+
+```typescript
+// 推荐模式：在 store action 中处理请求
+const fetchList = async (params) => {
+  set({ loading: true });
+  try {
+    const res = await getFeatureListApi(params);
+    set({ list: res.data, total: res.total });
+  } catch (e) {
+    message.error(formatMessage({ id: 'feature.fetchError' }));
+  } finally {
+    set({ loading: false });
+  }
+};
+```
+
+## 校验
+
+- 用浏览器 Network 面板确认请求路径、方法与参数是否正确。
+- 验证成功与失败分支 UI 是否都有正确反馈。
+- 运行 lint 确认无报错：
+
+```bash
+pnpm lint
+```
+
+- 提交前确认页面新增用户可见文案未出现硬编码（日志/调试输出除外）。
+- 提交前确认 `src/locale/index.js` 新增的 key 已执行 `pnpm intl:once` 同步生成。
+
+## i18n 门禁
+
+- 所有新增/修改的用户可见文案（按钮、提示、标签等）必须有 i18n key。
+- 对应 key 必须在 `src/locale/index.js` 中定义（源文件）。
+- 运行 `pnpm intl:once` 后 `src/locale/zh-CN.json` 与 `src/locale/en-US.json` 必须同步更新。
+- 不要只改生成的 JSON 文件而漏掉 `src/locale/index.js` 源文件。

--- a/frontend/.claude/skills/capabilities/tier0-ui-high-fidelity-build.md
+++ b/frontend/.claude/skills/capabilities/tier0-ui-high-fidelity-build.md
@@ -1,0 +1,120 @@
+---
+name: tier0-ui-high-fidelity-build
+description: 在 Tier0 Edge/Enterprise 前端中进行页面与组件高还原开发。用于按设计稿/截图/参考页实现高还原 UI、拆分组件、适配响应式与补齐交互状态。
+---
+
+# Tier0 UI 高还原开发（Edge/Enterprise）
+
+## 概览
+
+在不破坏现有技术栈与风格的前提下，高还原交付页面与组件。
+
+## 强制规范：组件复用优先（最高优先级）
+
+> 本节规则优先级高于所有其他指导，任何情况下不得绕过。
+
+### 组件选用优先级
+
+1. **项目已有封装组件**（如 `ProTable`、`usePagination`、`AuthWrapper`）— 优先复用，避免重复造轮子。
+2. **Ant Design 5.x 组件**— 满足需求的首选 UI 组件库。
+3. **Carbon Design System 图标**（`@carbon/icons-react`）— 项目唯一图标库，禁止引入其他图标库。
+4. **自定义封装**— 仅在上述均无法满足需求时才新建组件。
+
+### 常用项目组件速查
+
+```
+需要表格？         → ProTable（@/components/pro-table）
+需要分页？         → usePagination（@/hooks）
+需要国际化？       → useTranslate（@/hooks）
+需要响应式？       → useMediaSize（@/hooks）
+需要 Tab 生命周期？→ useActivate（@/contexts/tabs-lifecycle-context）
+需要时间格式化？   → formatTimestamp（@/utils/format）
+需要权限控制？     → AuthWrapper（@/components/auth）
+需要 API 请求？    → ApiWrapper（@/utils/request）
+需要弹窗确认？     → Popconfirm 或 Modal（antd）
+```
+
+### 禁止引入新 UI 库
+
+严格禁止在页面和组件开发中引入 Ant Design 以外的 UI 组件库。
+
+## 工作流
+
+1. 先提炼设计约束：间距、字号、颜色、状态、交互、断点。
+2. 在同应用中找最近似页面/组件并复用结构。
+3. 开发前先核对组件契约：
+   - 优先使用项目已有组件（`ProTable`、`AuthWrapper` 等）。
+   - 再使用 Ant Design 5.x 原生组件。
+   - 实现前先搜索 `src/components/` 确认是否有可复用实现。
+4. 分层实现：
+   - 页面骨架
+   - 功能区块
+   - 可复用组件
+5. 优先沿用现有栈：
+   - Ant Design 5.x 组件
+   - SCSS Modules（`.module.scss`）
+   - CSS 变量（`var(--supos-*)`）
+6. 补齐状态：`loading/empty/error/disabled/success`。
+7. 用并排对比方式微调：优先改间距和行高，再改其余细节。
+8. 处理可见文案时严格走国际化（强制）：
+   - 使用 `useTranslate()` 或 `useTranslate('ComponentName')` 获取格式化函数。
+   - 不在 JSX 中直接写用户可见字符串（按钮、标题、说明、空态、报错等）。
+   - 不在模块级静态变量里存放"已翻译文案"；静态配置只存 i18n key，渲染时再取翻译结果。
+   - 新增 key 先写入 `src/locale/index.js`，再运行 `pnpm intl:once` 同步生成 JSON 文件。
+
+## 样式约束
+
+颜色规则见 CLAUDE.md `### UI 开发` 节。截图/设计稿色值映射使用 `$match-screenshot-colors`（含变量速查表）。
+
+## 字体与图标规范
+
+- **字体**：使用 IBM Plex Sans（全局默认），禁止在组件内手写 `font-family`。
+- **图标**：只使用 `@carbon/icons-react`，示例：`import { Search, Close } from '@carbon/icons-react'`；禁止引入其他图标库。
+
+## 组件结构规范
+
+```
+pages/
+  feature-name/
+    index.tsx              # 主页面组件
+    index.module.scss      # 页面样式
+    components/            # 页面私有组件
+      Component.tsx
+      Component.module.scss
+```
+
+- 页面私有组件放路由下 `components/`。
+- 应用级复用组件放 `src/components/`。
+- 使用 `@/` 别名引用本应用模块（映射到 `apps/web/src/`）。
+
+## 组件拆分与注释触发条件
+
+- 满足任一条件时，拆分为独立子组件文件：
+  - 子组件超过 40 行且具备独立 props 与渲染逻辑。
+  - 配置/映射数据超过 5 项（如状态映射、图标映射、字段组）。
+  - 工具函数超过 3 个，或单个函数超过 10 行。
+  - 同一块 UI 在 2 个及以上页面复用。
+- 仅在"非显而易见逻辑"前加简洁注释（复杂条件、业务约束、workaround），避免注释复述代码字面含义。
+
+## Form 与 Modal 规则（强制）
+
+- `initialValues`、字段规则、字段分组、复杂 `label/placeholder` 等配置优先提取为语义化常量，不内联在 `<Form>` JSX。
+- 对动态字段显隐、联动校验、提交前数据整形等逻辑，拆成独立函数并命名，避免在 JSX 中堆叠表达式。
+
+## 代码风格约束
+
+- TypeScript 优先，组件用 `*.tsx`。
+- SCSS Modules，class 名使用 kebab-case。
+- 使用 `classnames` 库处理条件 class。
+- 导入分组：React → 第三方 → 本地组件 → 样式。
+- `import { type FC }` 方式导入类型。
+- 组件使用 `FC` 类型声明。
+
+## 质量标准
+
+- 不引入相邻页面视觉回归。
+- 不新增 UI 库。
+- 不引入无说明的硬编码色值。
+- 不引入新的硬编码业务文案（日志/调试输出除外）。
+- 原逻辑未改动时，不删除或改写用户已有注释。
+- 提交前清理 `console.log` 调试代码。

--- a/frontend/.claude/skills/capabilities/tier0-writing-plans-lite.md
+++ b/frontend/.claude/skills/capabilities/tier0-writing-plans-lite.md
@@ -1,0 +1,52 @@
+---
+name: tier0-writing-plans-lite
+description: 为 Tier0 Edge/Enterprise 多步骤需求编写轻量可执行计划。用于需求较复杂、跨后端接口/service/页面/组件改动、或需要先对齐实施路径再编码的场景。
+---
+
+# Tier0 轻量计划编写（Edge/Enterprise）
+
+## 概览
+
+输出一个短而可执行的实施计划，重点是"下一步怎么做"，不是写长文档。  
+适用：跨层改动、风险较高、多人协作、需求边界不清时。
+
+## 输出格式
+
+计划建议保存到：`docs/plans/YYYY-MM-DD-<feature>.md`
+
+文档头固定包含：
+
+```markdown
+# <功能名> 实施计划
+
+**目标：** <1-2 句>
+**范围：** <改哪些，不改哪些>
+**风险：** <最多 3 条>
+```
+
+正文保持 5-9 步，每步包含：
+
+1. 改动目标
+2. 具体文件路径
+3. 完成标准
+4. 校验命令
+
+## 计划粒度
+
+- 每步 5-20 分钟可完成。
+- 每步只做一件事，避免混合任务。
+- 路径必须写到文件级（例如 `apps/web/src/apis/inter-api/feature.ts` 或 `apps/web/src/pages/feature/index.tsx`）。
+
+## Tier0 Edge/Enterprise 推荐阶段
+
+1. 接口确认（后端 API 路径/方法/字段确认）
+2. Service 层封装（`src/apis/inter-api/`）
+3. 页面与状态流对接（store/hook + service）
+4. UI 还原与交互细节（组件、样式、空态）
+5. i18n 补齐与回归检查
+
+## 约束
+
+- 不强制 TDD、worktree、子代理流程。
+- 不写超长"百科式"计划，优先可执行性。
+- 计划批准后再进入编码。

--- a/frontend/.claude/skills/match-screenshot-colors/skill.md
+++ b/frontend/.claude/skills/match-screenshot-colors/skill.md
@@ -1,0 +1,165 @@
+---
+name: match-screenshot-colors
+description: 分析截图或设计稿中的颜色，将其映射到项目的两级 CSS 变量体系（--supos-t-* 主题级 / --supos-* 应用级）。用户提供截图还原需求、UI 色值匹配、颜色一致性修正时使用。
+---
+
+# 截图颜色映射到 CSS 变量
+
+## 使用时机
+
+- 用户提供截图要求还原页面样式
+- 需要将设计稿色值对应到项目 CSS 变量
+- 页面存在硬编码色值，需替换为 CSS 变量
+- 检查颜色与现有主题是否一致
+
+## 两级变量体系
+
+项目使用两级 CSS 变量：
+
+1. **主题级变量**（`--supos-t-*`）— 定义于 `apps/web/src/theme/theme.scss`，基础色盘定义
+2. **应用级变量**（`--supos-*`）— 定义于 `apps/web/src/index.scss :root` / `.dark`，语义化映射
+
+**组件样式只允许使用应用级变量（`--supos-*`），禁止直接使用主题级变量（`--supos-t-*`）。**
+
+## 工作流程
+
+### 第 1 步：分析截图颜色
+
+使用 Read 工具读取截图，识别各区域的色值：
+
+- 背景色
+- 文字色
+- 边框色
+- 卡片/容器背景
+- 交互元素色（按钮、链接、悬停状态）
+- 状态/强调色
+
+### 第 2 步：在主题级找到对应色
+
+读取 `apps/web/src/theme/theme.scss`，找到色盘中与截图色值最接近的变量：
+
+```
+截图色 #f4f4f4 → --supos-t-gray-color-10
+截图色 #e0e0e0 → --supos-t-gray-color-20
+截图色 #161616 → --supos-t-gray-color-100
+```
+
+### 第 3 步：找到对应的应用级变量（关键步骤）
+
+**此步骤决定最终使用哪个变量，必须严格执行。**
+
+1. 读取 `apps/web/src/index.scss`
+2. **只在 `:root` 段**查找匹配的应用级变量
+3. **只在 `.dark` 段**确认暗色主题映射
+4. **禁止直接使用** `--supos-t-*` 变量
+5. 若无合适的应用级变量，考虑是否需要在 `index.scss` 中新增
+
+建立映射表，只使用应用级变量：
+
+```
+背景 #f4f4f4 → var(--supos-craft-bg-color)
+边框 #e0e0e0 → var(--supos-border-color)
+文字 #161616 → var(--supos-text-color)
+卡片背景 #fff → var(--supos-card-color)
+```
+
+### 第 4 步：定位页面文件
+
+确认对应的页面文件和 SCSS Module，读取后识别需要更新颜色的元素。
+
+### 第 5 步：应用 CSS 变量
+
+更新 SCSS Module，将硬编码色值替换为 CSS 变量：
+
+```scss
+// ✅ 正确
+.myComponent {
+  color: var(--supos-text-color);
+  background: var(--supos-bg-color);
+  border: 1px solid var(--supos-border-color);
+}
+
+// ❌ 错误
+.myComponent {
+  color: #161616;
+  background: #ffffff;
+  border: 1px solid #e0e0e0;
+}
+```
+
+## 颜色匹配优先级
+
+替换色值时，按以下优先级选择变量：
+
+1. **精确色值匹配** — 找到与原色值完全相同的应用级变量
+2. **近似色值匹配** — 找到色值相近的应用级变量（同色阶范围内）
+3. **语义匹配** — 仅在前两步均无合适变量时才考虑语义含义
+
+**反例（错误做法）：**
+
+- 原色：`--supos-t-gray-color-50`（#8d8d8d，中灰）
+- 错误选择：`--supos-description-card-color`（映射到 gray-70 = #525252，明显偏深）
+- 原因：名称语义相似，但实际色值差异过大
+
+**正例（正确做法）：**
+
+- 原色：`--supos-t-gray-color-50`（#8d8d8d，中灰）
+- 正确选择：`--supos-icon-disabled-color`（映射到 gray-40 = #a8a8a8，色值相近）
+
+## 处理已有主题级变量
+
+如果发现组件内已直接使用了 `--supos-t-*` 变量：
+
+1. 确认该颜色的用途（背景、文字、边框等）
+2. 在 `:root` 中找到语义和色值都匹配的应用级变量
+3. 替换为应用级变量
+
+常见替换：
+
+- `var(--supos-t-gray-color-10)` → `var(--supos-craft-bg-color)` 或 `var(--supos-card-bg)`
+- `var(--supos-t-gray-color-100)` → `var(--supos-text-color)`
+- `var(--supos-t-white-color)` → `var(--supos-card-color)` 或 `var(--supos-bg-color)`
+
+## 常用应用级变量速查
+
+**以下变量均定义于 `apps/web/src/index.scss :root` 段，组件样式应优先使用这些变量。**
+
+### 背景
+
+- `--supos-bg-color` — 页面主背景（亮色主题为白色）
+- `--supos-card-color` — 卡片/面板背景（白色）
+- `--supos-craft-bg-color` — 工作区背景（#f4f4f4）
+- `--supos-header-bg-color` — 头部背景
+- `--supos-card-bg` — 备用卡片背景
+
+### 文字
+
+- `--supos-text-color` — 主文字色（亮色主题为 #161616）
+- `--supos-anti-text-color` — 反色文字（深色背景上的白字）
+
+### 边框
+
+- `--supos-border-color` — 标准边框
+- `--supos-home-border-color` — 首页边框
+
+### 交互状态
+
+- `--supos-menu-hover-color` — 菜单悬停
+- `--supos-card-hover-color` — 卡片悬停
+- `--supos-menu-active-color` — 菜单选中
+- `--supos-theme-color` — 主题色（蓝或绿）
+
+### 其他
+
+- `--supos-nocheck-color` — 未选中/非激活状态
+- `--supos-boxshadow-color` — 阴影色
+
+## 输出格式
+
+执行完成后输出：
+
+1. **颜色分析** — 截图中识别到的色值列表
+2. **主题变量映射** — 色盘中匹配到的变量
+3. **应用变量映射** — 最终使用的语义变量
+4. **实施结果** — 更新后的 SCSS，已全部替换为 CSS 变量
+5. **验证** — 确认无硬编码色值残留

--- a/frontend/.claude/skills/scenarios/tier0-delivery-orchestrator.md
+++ b/frontend/.claude/skills/scenarios/tier0-delivery-orchestrator.md
@@ -1,0 +1,119 @@
+---
+name: tier0-delivery-orchestrator
+description: Tier0 Edge/Enterprise 前端需求总控编排技能。用于端到端交付场景：从后端接口确认、service 层封装、页面 API 对接、UI 高还原开发到提交门禁检查。用户提到"总控 skill""端到端交付""全流程开发"时使用。
+---
+
+# Tier0 交付总控（Edge/Enterprise）
+
+## 概览
+
+将一个需求按固定阶段串起来执行，默认按以下子技能顺序调度：
+
+1. `$tier0-writing-plans-lite`（复杂需求先产出轻量计划）
+2. 接口层确认（后端 go-zero REST API 定义确认）
+3. `$tier0-page-api-integration`（service 封装 + 页面对接）
+4. `$tier0-ui-high-fidelity-build`（UI 高还原 + i18n）
+5. `$tier0-systematic-debugging`（仅在异常或回归失败时触发）
+
+## 输入契约
+
+开始执行前先确认最小输入：
+
+- 目标应用（通常是 `apps/web`）
+- 目标页面或路由路径
+- 后端 API 接口路径与方法（若接口是新增，先确认 go-zero `.api` 定义）
+- UI 参考来源（设计稿、截图或现有页面）
+- 验收标准（业务 + 视觉）
+
+若信息不足，只追问缺失的最小字段。
+
+## 通用编辑约束
+
+- 在"代码逻辑未改变"的情况下，不删除、不改写用户已有注释。
+- 若因逻辑调整必须改注释，只做最小必要改动，不顺手清洗或重写其他注释。
+- 新增注释与文件写回统一保持 UTF-8 编码，避免中文注释乱码。
+
+## 主流程
+
+### 阶段 0：基线同步（强制）
+
+- 拉取最新代码后先确认依赖安装：
+
+```bash
+cd frontend && pnpm install
+```
+
+- 确认开发环境可正常启动：
+
+```bash
+pnpm dev:web
+```
+
+### 阶段 1：轻量计划（可选但推荐）
+
+- 需求跨多层（后端接口 + service + 页面 + UI）时，先调用 `$tier0-writing-plans-lite`。
+- 计划经确认后再进入开发阶段。
+
+### 阶段 2：接口层确认
+
+- 确认后端已有对应 REST API（路径、方法、请求/响应结构）。
+- 若接口是新增，先在 `backend/http/supos/<module>.api` 中确认定义，并由后端同学执行 goctl 生成 handler。
+- 确认接口文档或 Swagger 可访问（`http://localhost:8080/swagger/`）。
+- 将接口约定落到 `src/apis/inter-api/<module>.ts` 中的函数签名。
+
+### 阶段 3：页面 API 对接
+
+- 调用 `$tier0-page-api-integration`。
+- 在 `src/apis/inter-api/<module>.ts` 中封装 API 函数。
+- 在页面/store 中接入 service，补齐 `loading/empty/error/success` 状态。
+- 对接产生的用户可见文案（成功提示、失败提示、空态等）统一走国际化 key。
+
+### 阶段 4：UI 实现
+
+- 调用 `$tier0-ui-high-fidelity-build`。
+- 根据设计源实现或修正页面与组件。
+- 保持与同模块页面一致的组件与样式风格。
+- 检查新增用户可见文案是否全部走国际化，并同步补齐 `src/locale/index.js`（源文件）。
+- 若存在用户可见硬编码文案（日志/调试输出除外），不得进入下一阶段。
+
+### 阶段 5：异常处理（按需）
+
+- 任何阶段出现失败或回归异常，调用 `$tier0-systematic-debugging`。
+- 必须先给出根因证据链，再进入修复。
+
+## 输出要求
+
+输出结果必须包含：
+
+- 改动文件列表
+- 执行命令列表
+- 校验结果
+- 未决假设或阻塞项
+
+## 提交前门禁（强制）
+
+- 提交前必须通过 lint 检查：
+
+```bash
+pnpm lint
+```
+
+- 提交前确认构建不报错（快速验证）：
+
+```bash
+pnpm build:web
+```
+
+- i18n 门禁：
+  - 新增/修改的用户可见文案必须在 `src/locale/index.js` 中有对应 key。
+  - 运行 `pnpm intl:once` 确认 `zh-CN.json` 与 `en-US.json` 已同步生成。
+- 提交前清理 `console.log` 调试代码。
+
+## 停机条件
+
+出现以下情况先停下并询问用户：
+
+- API 合同不明确，继续会造成破坏性改动。
+- 设计信息不足，无法承诺高还原。
+- 用户要求与当前 Monorepo 边界冲突。
+- 排障连续 3 次假设失败，需先复盘数据流设计。

--- a/frontend/.claude/skills/scenarios/tier0-systematic-debugging.md
+++ b/frontend/.claude/skills/scenarios/tier0-systematic-debugging.md
@@ -1,0 +1,130 @@
+---
+name: tier0-systematic-debugging
+description: 在 Tier0 Edge/Enterprise 项目中进行系统化排障。用于构建报错、接口异常、页面行为异常、联调问题等场景，要求先定位根因再修复，禁止直接猜修。
+---
+
+# Tier0 系统化排障（Edge/Enterprise）
+
+## 概览
+
+目标：先找根因，再修复。  
+原则：没有证据链，不提交修复方案。
+
+## 触发时机
+
+- lint 或 build 报错
+- 页面与后端接口联调异常
+- 接口返回不符合预期
+- 运行时报错或页面白屏
+- "修了一个又冒出另一个"的反复问题
+
+## 四阶段流程
+
+### 阶段 1：根因定位
+
+1. 固定复现路径（输入、环境、步骤），并先做基线检查：
+
+```bash
+pnpm install
+pnpm lint
+```
+
+2. 逐行读错误信息和调用栈。
+3. 对比近期变更（git diff、依赖、配置、环境变量）。
+4. 先按错误类别分流，避免混修：
+   - 依赖缺失（`Cannot find module xxx`）
+   - TypeScript 类型错误（编译阶段）
+   - 接口路径/参数错误（Network 面板确认）
+   - 状态管理数据流异常（Zustand store 检查）
+   - i18n key 缺失或格式错误
+   - 真实业务逻辑缺陷
+5. 在关键边界加日志，形成证据链：
+   - 页面 → store/hook
+   - store/hook → API service
+   - API service → 后端接口
+   - 接口响应 → 数据映射
+6. 明确"坏数据从哪一层开始出现"。
+
+### 阶段 2：模式对比
+
+1. 在同仓库找一个"已工作的同类实现"。
+2. 对比 API service 封装、请求参数、响应映射、错误处理。
+3. 列出差异并标记最可疑项。
+
+### 阶段 3：假设验证
+
+1. 一次只验证一个假设。
+2. 只做最小改动验证假设。
+3. 记录验证结果：
+   - 成立 → 进入修复
+   - 不成立 → 回到阶段 1
+
+### 阶段 4：修复与回归
+
+1. 修根因，不修症状。
+2. 运行最小回归集：
+   - `pnpm lint`
+   - 必要时 `pnpm build:web` 确认无构建错误
+   - 浏览器手动验证核心路径
+3. 说明修复点与证据链闭环。
+
+## 常见问题排查剧本
+
+以下剧本只用于快速建立证据，不替代"四阶段流程"。
+
+### 1. 依赖/安装问题（pnpm）
+
+- 先确认在 `frontend/` 根目录执行命令：
+
+```bash
+pnpm install
+```
+
+- 若锁文件/缓存可疑，再执行：
+
+```bash
+pnpm clean
+pnpm install
+```
+
+### 2. 构建或 lint 报错
+
+```bash
+pnpm lint
+pnpm build:web
+```
+
+- 若错误集中在某个文件/模块，先在该范围收敛修复，再整体回归。
+- 禁止用 `@ts-ignore/@ts-expect-error` 作为临时止血提交。
+
+### 3. 接口联调失败
+
+- 用 Network 面板确认请求路径、方法、参数是否与后端约定一致。
+- 确认 `.env` 或 `config/supos.dev.ts` 中的代理配置是否正确。
+- 确认后端 Swagger（`http://localhost:8080/swagger/`）与实际请求是否匹配。
+- 确认 `src/apis/inter-api/<module>.ts` 中的接口路径与后端 `.api` 定义一致。
+
+### 4. 开发服务器无法启动/无响应
+
+- 端口冲突：检查 `3000` 等端口占用。
+- 环境变量：核对 `.env` 文件的必填项（`API_PROXY_URL` 等）。
+- 代理配置：检查 `config/supos.dev.ts` 中的 proxy 设置。
+
+### 5. 页面显示异常/样式错乱
+
+- 检查 CSS 变量是否正确引用（`var(--supos-*)`，不要硬编码色值）。
+- 检查 SCSS Module 是否正确导入（`import styles from './index.module.scss'`）。
+- 检查 Ant Design 组件版本兼容性。
+
+### 6. i18n key 缺失或文案不正确
+
+- 确认 `src/locale/index.js` 中已定义对应 key。
+- 运行 `pnpm intl:once` 重新生成 `zh-CN.json` 与 `en-US.json`。
+- 确认 `useTranslate()` 的 prefix 与 key 路径匹配。
+- 检查是否混入了硬编码文案（非 i18n key 的中英文字符串）。
+
+## 红线
+
+- 禁止"先试试这个改动"式猜修。
+- 禁止一次提交混入多个不相关修复。
+- 连续 3 次假设失败，先暂停并复盘数据流或组件设计。

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,102 @@
+# AGENTS.md
+
+> **同步维护要求**
+>
+> - 本目录中的 `CLAUDE.md` 与 `AGENTS.md` 是配对文档
+> - AI 修改其中任意一份时，必须同步检查并更新另一份的对应说明
+> - 前端规范的 Canonical 细则仍以 `CLAUDE.md` 为主，`AGENTS.md` 负责 skills 导航与执行入口
+> - `.claude/skills/` 是本仓库 skills 的唯一事实来源，Codex 使用 `.agents/skills/`
+> - 若映射缺失，请在 `Tier0` 根仓库执行 `bash shell/map-agent-skills.sh`
+> - 根仓库 `update-*` 脚本会在同步代码后自动补齐 skills 映射
+
+## 1) Canonical 规范来源
+
+- 执行任何开发任务前，先遵循 [CLAUDE.md](./CLAUDE.md) 的 Canonical 约束。
+- `AGENTS.md` 仅维护：skills 导航、调用顺序、少量补充约定。
+- 后续新增/修改规则时，先更新 `CLAUDE.md`，并同步检查 `AGENTS.md` 的导航与入口说明是否需要更新。
+
+## 2) Skills 导航
+
+以下是项目内可用 skills（版本化到仓库）。
+
+### 场景层（scenarios）
+
+- `tier0-delivery-orchestrator`：端到端交付编排（接口确认 → service 封装 → 页面对接 → UI 高还原）  
+  file: `.claude/skills/scenarios/tier0-delivery-orchestrator.md`
+- `tier0-systematic-debugging`：系统化排障（先证据后修复，禁止猜修）  
+  file: `.claude/skills/scenarios/tier0-systematic-debugging.md`
+
+### 能力层（capabilities）
+
+- `tier0-page-api-integration`：页面与 `src/apis/inter-api` 的标准对接  
+  file: `.claude/skills/capabilities/tier0-page-api-integration.md`
+- `tier0-ui-high-fidelity-build`：页面与组件高还原开发（含严格 i18n 约束）  
+  file: `.claude/skills/capabilities/tier0-ui-high-fidelity-build.md`
+- `tier0-writing-plans-lite`：轻量可执行计划编写  
+  file: `.claude/skills/capabilities/tier0-writing-plans-lite.md`
+- `i18n-setup`：i18n 配置与校验流程  
+  file: `.claude/skills/capabilities/i18n-setup.md`
+- `match-screenshot-colors`：截图颜色映射到项目 CSS 变量体系  
+  file: `.claude/skills/match-screenshot-colors/skill.md`
+
+## 3) Skill 调用规则
+
+- 用户显式提到 skill 名称（如 `$tier0-ui-high-fidelity-build`）时，优先使用该 skill。
+- 多阶段需求优先从 `tier0-delivery-orchestrator` 开始。
+- 优先场景层编排，再调用能力层。
+- 优先通过 `Skill` 工具调用 skills；若 skill 缺失/不可读，需明确说明并采用最近 fallback。
+- 本仓库使用小写 `skill.md` 作为部分 skill 入口，映射脚本会自动转换为 Codex 可识别的 `SKILL.md` 包装目录。
+- 执行映射脚本后，需要重开 Codex 会话刷新 skills 列表。
+
+### 用户意图 → Skill 映射
+
+| 你想做什么                             | 用哪个 Skill                              |
+| -------------------------------------- | ----------------------------------------- |
+| 新建一个完整页面（接口 + 样式 + 状态） | `tier0-delivery-orchestrator`             |
+| 照着设计稿还原一个页面                 | `tier0-ui-high-fidelity-build`            |
+| 后端给了新接口，要对接到页面           | `tier0-page-api-integration`              |
+| 加国际化 / 多语言支持                  | `i18n-setup`                              |
+| 截图颜色映射到 CSS 变量                | `match-screenshot-colors`                 |
+| 遇到报错 / 功能行为不对                | `tier0-systematic-debugging`              |
+| 写一个执行计划                         | `tier0-writing-plans-lite`                |
+| **加个新功能 / 不确定用哪个**          | **`tier0-delivery-orchestrator`（兜底）** |
+
+---
+
+## 项目快速参考
+
+### 目录结构
+
+- `apps/web`：主 React 18 + Vite 前端
+- `apps/services-express`：Express v5 API（CopilotKit + 健康检查）
+- `packages/`：共享脚本与 TS 配置
+- `plugins/`：模块联邦插件
+
+### 常用命令
+
+```bash
+pnpm install
+pnpm dev:web                  # 启动前端
+pnpm dev:servicesExpress      # 启动 AI 服务（按需）
+pnpm build:web
+pnpm lint
+pnpm intl:once                # 生成 i18n JSON
+```
+
+### 业务模块速查
+
+- **核心**：UNS、采集流/事件流、仪表盘、插件管理、开放数据、账号/角色
+- **主要路由**：`/home`、`/uns`、`/collection-flow`、`/EventFlow`、`/dashboards`、`/plugin-management`
+- **权限**：`pageList/buttonList` 控制菜单与按钮；`AuthWrapper` 包裹权限组件
+- **API 前缀**：`/inter-api/supos/...`；CopilotKit：`/copilotkit`
+
+### 环境变量（常用）
+
+- `API_PROXY_URL`、`VITE_ASSET_PREFIX`、`VITE_REMOTE_PREFIX`、`PORT`、`LLM_*`
+- 登录：`loginPath` 或 `/tier0-login`；免登录 `/freeLogin?token=...&redirectUri=...`
+
+### 常见排查
+
+- 登录循环/403：检查 `loginPath`、`authEnable`、资源启用与用户 `pageList`
+- 接口报错：检查 `.env` 代理配置
+- 插件加载失败：确认插件安装与联邦配置

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+> **同步维护要求**
+>
+> - 本目录中的 `CLAUDE.md` 与 `AGENTS.md` 是配对文档
+> - AI 修改其中任意一份时，必须同步检查并更新另一份的对应说明
+> - `.claude/skills/` 是本仓库 skills 的唯一事实来源，Codex 使用 `.agents/skills/`
+> - 若映射缺失，请在 `Tier0` 根仓库执行 `bash shell/map-agent-skills.sh`
+>
+> 本节为当前有效约束；若与后文历史内容冲突，以本节为准。所有文字类描述一律使用中文。
+
+## AI 开发规范（Canonical）
+
+### 语言
+
+- 所有输出（注释、文档、commit 信息、对话）必须使用中文。
+
+### Skills
+
+- Skills 单一来源：`.claude/skills/`；Codex 映射目录：`.agents/skills/`。
+- 始终通过 `Skill` 工具调用，不要手动读取 skill 文件。
+- 若 Codex 未识别到 skills，在 `Tier0` 根仓库执行 `bash shell/map-agent-skills.sh`，然后重开会话。
+- Skills 导航详见 [AGENTS.md](./AGENTS.md)。
+
+### 复用优先
+
+- 实现前先搜索 `src/components/`、`src/hooks/`、`src/utils/` 是否已有可用实现。
+- 高频易被忽略的工具：`ProTable`（`@/components/pro-table`）、`usePagination`、`useTranslate`、`ApiWrapper`（`@/utils/request`）。
+
+### UI 开发
+
+- 还原截图/设计稿时，**必须先调用 `match-screenshot-colors` skill** 映射颜色到 CSS 变量。
+- 颜色必须使用 `var(--supos-*)` CSS 变量，禁止硬编码色值（`#161616`、`#f4f4f4` 等）。
+- 优先使用应用级语义变量（`--supos-*`，定义于 `apps/web/src/index.scss :root`），禁止直接使用主题级变量（`--supos-t-*`）。
+- 图标只使用 `@carbon/icons-react`，禁止引入其他图标库。
+- 路由 import 使用 `react-router`，禁止 `react-router-dom`。
+- 样式使用 SCSS Modules，class 名 kebab-case。
+
+### i18n
+
+- 所有用户可见文案必须国际化，禁止硬编码中英文字符串。
+- React 组件内使用 `useTranslate()` 或 `useTranslate('ComponentName')`；非 React 场景使用 `getIntl`。
+- 词条源文件是 `src/locale/index.js`（中文源），**禁止只改生成的 JSON 文件**。
+- 新增词条后执行 `pnpm intl:once` 或 `pnpm intl:watch` 生成 `zh-CN.json` / `en-US.json`。
+- i18n key 末级名控制在 25 字符以内，优先短语义命名，禁止整句式 key。
+
+### API 层
+
+- 禁止在页面组件内直接使用 `axios` 或 `fetch`，统一通过 `src/apis/inter-api/<module>.ts` 封装。
+- 使用 `ApiWrapper`（`@/utils/request`）封装请求。
+- 所有 API 从 `src/apis/inter-api/index.ts` 统一导出。
+
+### 禁止项
+
+- 禁止在生产代码中遗留 `console.log`（提交前必须清理）。
+- 禁止使用 `@ts-ignore` / `@ts-expect-error` 作为永久方案。
+- 禁止硬编码颜色值、业务常量（角色名、状态码等）。
+- 禁止引入 `@carbon/icons-react` 以外的图标库。
+- 禁止引入 Ant Design 以外的 UI 组件库。
+- 排障禁止"先试试这个改动"式猜修，必须先定位根因。
+
+### 提交前检查
+
+- `pnpm lint` 无报错。
+- 若改动涉及 i18n：`src/locale/index.js` 已更新 → `pnpm intl:once` → 确认 JSON 同步。
+- 清理 `console.log` 和临时 `@ts-ignore`。
+- 机密配置放 `.env`，禁止提交。
+
+### 停机条件
+
+出现以下情况必须暂停并询问用户：
+
+- API 合同不明确，继续会造成破坏性改动。
+- 设计信息不足，无法确认高还原交付。
+- 排障连续 3 次假设失败，需先复盘数据流设计。


### PR DESCRIPTION
- 新增 frontend/CLAUDE.md：AI 开发规范 Canonical
- 新增 frontend/AGENTS.md：Codex skills 导航与调用入口
- 新增 .claude/skills/ 完整 skills 集合（scenarios/capabilities/match-screenshot-colors）
- 更新 .gitignore：取消对 AGENTS.md 的忽略