### PR TITLE
fix(web): 修复安装应用接口 URL 尾部空格导致 404

### DIFF
--- a/frontend/apps/web/src/apis/inter-api/app.ts
+++ b/frontend/apps/web/src/apis/inter-api/app.ts
@@ -5,4 +5,4 @@ const baseUrl = '/inter-api/supos/app';
 const api = new ApiWrapper(baseUrl);
 
 // 安装app
-export const installApp = async (data?: Record<string, unknown>) => api.post('/install ', data);
+export const installApp = async (data?: Record<string, unknown>) => api.post('/install', data);


### PR DESCRIPTION
## 问题

应用管理页安装/导入应用一直失败。

`frontend/apps/web/src/apis/inter-api/app.ts` 中 `installApp` 的请求路径为 `'/install '`（尾部多一个空格）。浏览器会将其编码为 `%20`，实际请求 `POST /inter-api/supos/app/install%20`，后端无此路由返回 404。

## 验证

在 enterprise-sib 环境（部署自本仓库，`/home/ubuntu/edge/deploy`）实测：

- 不带空格：`POST /inter-api/supos/app/install` → 400（路由存在，进入参数校验）
- 带 %20：`POST /inter-api/supos/app/install%20` → 404

## 改动

去掉 `installApp` 请求路径的尾部空格，仅 1 字节。已全量检索 `frontend/apps/web/src/apis`，仅此一处 URL 带空格。

注：运行中的 enterprise-sib 环境已对容器内构建产物做过等效热修复并验证通过；本 PR 修复源码，下次构建镜像即生效。

> 本仓库没有 dev 分支，PR 目标为默认分支 main。